### PR TITLE
Add ParseError and required_node helper; pass `source_path` to parsers

### DIFF
--- a/lib/amazon_order/parser.rb
+++ b/lib/amazon_order/parser.rb
@@ -15,9 +15,9 @@ module AmazonOrder
     def orders
       @orders ||= doc.css(".order-card").map do |e|
         if e.css('.order-info').size == 1
-          AmazonOrder::Parsers::DigitalOrder.new(e, fetched_at: fetched_at)
+          AmazonOrder::Parsers::DigitalOrder.new(e, fetched_at: fetched_at, source_path: @filepath)
         elsif e.css('.order-header').size == 1
-          AmazonOrder::Parsers::NormalOrder.new(e, fetched_at: fetched_at)
+          AmazonOrder::Parsers::NormalOrder.new(e, fetched_at: fetched_at, source_path: @filepath)
         else
           raise("Unknown pattern: #{e}")
         end

--- a/lib/amazon_order/parsers/base.rb
+++ b/lib/amazon_order/parsers/base.rb
@@ -1,11 +1,14 @@
 module AmazonOrder
   module Parsers
+    class ParseError < StandardError; end
+
     class Base
-      attr_accessor :fetched_at
+      attr_accessor :fetched_at, :source_path
 
       def initialize(node, options = {})
         @node = node
         @fetched_at = options[:fetched_at]
+        @source_path = options[:source_path]
         @containing_object = options[:containing_object]
       end
 
@@ -26,6 +29,10 @@ module AmazonOrder
         self.class::ATTRIBUTES.map{|a| send(a) }
       end
 
+      def required_node(selector, index: 0, context:)
+        @node.css(selector)[index] || raise_parse_error(selector: selector, index: index, context: context)
+      end
+
       def parse_date(date_text)
         begin
           Date.parse(date_text)
@@ -33,6 +40,30 @@ module AmazonOrder
           m = date_text.match(/\A(?<year>\d{4})年(?<month>\d{1,2})月(?<day>\d{1,2})日\z/)
           Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
         end
+      end
+
+      private
+
+      def raise_parse_error(selector:, index:, context:)
+        message = [
+          "#{self.class.name} failed to parse #{context}",
+          "selector=#{selector.inspect}",
+          "index=#{index}",
+          "source_path=#{source_path.inspect}",
+          "node=#{short_node_snapshot}"
+        ].compact.join(', ')
+
+        raise ParseError, message
+      end
+
+      def short_node_snapshot
+        snapshot = if @node.respond_to?(:to_html)
+          @node.to_html
+        else
+          @node.text
+        end
+
+        snapshot.to_s.gsub(/\s+/, ' ').strip[0, 500]
       end
     end
   end

--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -15,7 +15,7 @@ module AmazonOrder
       end
 
       def order_total
-        @_order_total ||= @node.css('.order-header .a-col-left .a-column')[1].text.split.last.gsub(/[^\d\.]/, '').to_f
+        @_order_total ||= required_node('.order-header .a-col-left .a-column', index: 1, context: 'order_total').text.split.last.gsub(/[^\d\.]/, '').to_f
       end
 
       def order_details_path

--- a/spec/amazon_order/parsers/base_spec.rb
+++ b/spec/amazon_order/parsers/base_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe AmazonOrder::Parsers::Base do
+  let(:node) { Nokogiri::HTML.fragment('<div class="order-card"><span class="present">ok</span></div>') }
+  let(:parser) { described_class.new(node, source_path: 'spec/fixtures/source.html') }
+
+  describe '#required_node' do
+    it 'returns the node matching selector and index' do
+      expect(parser.required_node('.present', context: 'title').text).to eq('ok')
+    end
+
+    it 'raises ParseError with parser context when the node is missing' do
+      expect {
+        parser.required_node('.missing', index: 2, context: 'order_total')
+      }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
+        expect(error.message).to include('AmazonOrder::Parsers::Base')
+        expect(error.message).to include('order_total')
+        expect(error.message).to include('selector=".missing"')
+        expect(error.message).to include('index=2')
+        expect(error.message).to include('source_path="spec/fixtures/source.html"')
+        expect(error.message).to include('order-card')
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Improve robustness of HTML parsing by surfacing clearer, contextual errors when required nodes are missing.
- Make parsers aware of the original input file so error messages can include the `source_path` for debugging.
- Replace ad-hoc node indexing in `NormalOrder#order_total` with a shared helper that raises structured parse errors.

### Description
- Add `AmazonOrder::Parsers::ParseError` and a `required_node(selector, index: 0, context:)` helper to `lib/amazon_order/parsers/base.rb` that raises detailed errors including parser class, attribute context, selector, index, `source_path`, and a short node snapshot.
- Track `source_path` on parser instances via a new `source_path` attribute in `Base` and pass `source_path: @filepath` from `AmazonOrder::Parser#orders` in `lib/amazon_order/parser.rb` to both `DigitalOrder` and `NormalOrder` instances.
- Update `lib/amazon_order/parsers/normal_order.rb` to use `required_node` for `order_total` extraction instead of direct `@node.css(...)[1]` indexing.
- Add unit spec `spec/amazon_order/parsers/base_spec.rb` to cover successful lookup and raising of `ParseError` with expected message contents.

### Testing
- Ran Ruby syntax checks with `ruby -c` against `lib/amazon_order/parsers/base.rb`, `lib/amazon_order/parser.rb`, `lib/amazon_order/parsers/normal_order.rb`, and `spec/amazon_order/parsers/base_spec.rb`, all returning `Syntax OK`.
- Attempted `bundle exec rspec` but the `rspec` executable was not available in the environment so the full test suite could not be run.
- Attempted `bundle install` to enable running the test suite but it failed due to network access to `rubygems.org` returning `403 Forbidden`, blocking dependency installation and `rspec` execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5514d505048332bbcf73a8f2c6fc7a)