### PR TITLE
Ignore canceled orders without totals

### DIFF
--- a/lib/amazon_order/parser.rb
+++ b/lib/amazon_order/parser.rb
@@ -14,6 +14,8 @@ module AmazonOrder
 
     def orders
       @orders ||= doc.css(".order-card").map do |e|
+        next if canceled_without_order_total?(e)
+
         if e.css('.order-info').size == 1
           AmazonOrder::Parsers::DigitalOrder.new(e, fetched_at: fetched_at, source_path: @filepath)
         elsif e.css('.order-header').size == 1
@@ -21,7 +23,7 @@ module AmazonOrder
         else
           raise("Unknown pattern: #{e}")
         end
-      end
+      end.compact
     end
 
     def doc
@@ -30,6 +32,17 @@ module AmazonOrder
 
     def body
       @body ||= File.read(@filepath)
+    end
+
+    private
+
+    def canceled_without_order_total?(node)
+      return false unless node.css('.order-header').size == 1
+      return false unless node.css('.order-header .a-col-left .a-column')[1].nil?
+
+      node.css('.yohtmlc-shipment-status-primaryText, .delivery-box__primary-text').any? do |status_node|
+        status_node.text.strip == 'キャンセル済み'
+      end
     end
   end
 end

--- a/spec/amazon_order/parser_spec.rb
+++ b/spec/amazon_order/parser_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe AmazonOrder::Parser do
   context 'with single file' do
@@ -33,4 +34,56 @@ describe AmazonOrder::Parser do
       end
     end
   end
+
+  context 'with a canceled normal order that has no order total' do
+    let(:tempfile) { Tempfile.new(['canceled-order', '.html']) }
+    let(:filepath) do
+      tempfile.write(<<~HTML)
+        <div class="order-card js-order-card">
+          <div class="a-box-group a-spacing-base">
+            <div class="a-box a-color-offset-background order-header">
+              <div class="a-box-inner">
+                <div class="a-fixed-right-grid-col a-col-left">
+                  <div class="a-row">
+                    <div class="a-column a-span12 a-span-last">
+                      <span class="a-color-secondary a-text-caps">注文日</span>
+                      <span class="a-size-base a-color-secondary aok-break-word">2020年7月14日</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="a-fixed-right-grid-col a-col-right">
+                  <div class="a-row a-size-mini">
+                    <div class="yohtmlc-order-id">
+                      <span class="a-color-secondary a-text-caps">注文番号</span>
+                      <span class="a-color-secondary" dir="ltr">624-2345678-3456789</span>
+                    </div>
+                  </div>
+                  <div class="a-row"></div>
+                </div>
+              </div>
+            </div>
+            <div class="a-box delivery-box">
+              <div class="a-box-inner">
+                <div class="yohtmlc-shipment-status-primaryText">
+                  <span class="a-size-medium delivery-box__primary-text a-text-bold">キャンセル済み</span>
+                </div>
+                <span class="delivery-box__secondary-text">商品はキャンセルされました。 これらの商品については請求されていません。</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      HTML
+      tempfile.close
+      tempfile.path
+    end
+
+    after do
+      tempfile.close!
+    end
+
+    it 'ignores the order instead of raising when totals are read later' do
+      expect(described_class.new(filepath).orders).to eq([])
+    end
+  end
+
 end


### PR DESCRIPTION
### Motivation
- The parser raised `ParseError` when encountering canceled normal order cards that do not include an order-total column, so these no-charge cancellations should be skipped during `orders` loading to avoid errors when consumers call `order_total` later.

### Description
- Skip candidate nodes in `Parser#orders` by returning early with `next if canceled_without_order_total?(e)` and `compact` the resulting list.
- Add a private method `canceled_without_order_total?(node)` that returns true when the node has an `.order-header`, lacks the second `.a-column` (order total column), and contains a shipment status node whose text is `キャンセル済み` (checked via `.yohtmlc-shipment-status-primaryText` and `.delivery-box__primary-text`).
- Add a regression spec in `spec/amazon_order/parser_spec.rb` that builds a temporary Amazon.co.jp-style canceled order HTML and asserts the parser ignores it by returning an empty `orders` array.

### Testing
- Ran `ruby -c lib/amazon_order/parser.rb` which reported `Syntax OK`.
- Ran `ruby -c spec/amazon_order/parser_spec.rb` which reported `Syntax OK`.
- Attempted `bundle exec rspec spec/amazon_order/parser_spec.rb` but execution was blocked because the `rspec` executable is not installed and `bundle install` failed with a `403 Forbidden` error when fetching dependencies from `rubygems.org`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552344dbc8833284605cc1bfeb0b78)