### PR TITLE
Add racecourse weather monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ console> pp products.first.to_hash
  "https://images-fe.ssl-images-amazon.com/images/I/51TODrMIEnL.jpg"}
 ```
 
+
+#### Racecourse weather monitoring
+
+Monitor the daily forecast for JRA racecourses and list locations that exceed configurable weather thresholds. Forecasts are fetched from the Open-Meteo API using built-in racecourse coordinates.
+
+```ruby
+monitor = AmazonOrder::RacecourseWeatherMonitor.new(
+  thresholds: {
+    precipitation_probability: 60, # %
+    precipitation: 5.0,            # mm/day
+    wind_speed: 12.0,              # km/h
+    temperature_high: 35.0,        # °C
+    temperature_low: 0.0           # °C
+  }
+)
+
+monitor.weather_for(:tokyo)
+monitor.alerts([:tokyo, :kyoto, :hanshin])
+```
+
+Supported racecourse keys are `:sapporo`, `:hakodate`, `:fukushima`, `:niigata`, `:tokyo`, `:nakayama`, `:chukyo`, `:kyoto`, `:hanshin`, and `:kokura`.
+
 #### Export csv
 
 ```ruby

--- a/lib/amazon_order.rb
+++ b/lib/amazon_order.rb
@@ -7,6 +7,7 @@ require "amazon_order/parsers/normal_order"
 require "amazon_order/parsers/product"
 require "amazon_order/parser"
 require "amazon_order/writer"
+require "amazon_order/racecourse_weather_monitor"
 
 module AmazonOrder
 end

--- a/lib/amazon_order/racecourse_weather_monitor.rb
+++ b/lib/amazon_order/racecourse_weather_monitor.rb
@@ -1,0 +1,113 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
+module AmazonOrder
+  # Monitors JRA racecourse weather using the Open-Meteo forecast API.
+  class RacecourseWeatherMonitor
+    DEFAULT_API_ENDPOINT = 'https://api.open-meteo.com/v1/forecast'.freeze
+
+    RACECOURSES = {
+      'sapporo' => { name: '札幌競馬場', latitude: 43.0740, longitude: 141.3269 },
+      'hakodate' => { name: '函館競馬場', latitude: 41.7839, longitude: 140.7750 },
+      'fukushima' => { name: '福島競馬場', latitude: 37.7656, longitude: 140.4808 },
+      'niigata' => { name: '新潟競馬場', latitude: 37.9475, longitude: 139.1872 },
+      'tokyo' => { name: '東京競馬場', latitude: 35.6650, longitude: 139.4850 },
+      'nakayama' => { name: '中山競馬場', latitude: 35.7258, longitude: 139.9598 },
+      'chukyo' => { name: '中京競馬場', latitude: 35.0703, longitude: 136.9856 },
+      'kyoto' => { name: '京都競馬場', latitude: 34.9069, longitude: 135.7247 },
+      'hanshin' => { name: '阪神競馬場', latitude: 34.7792, longitude: 135.3628 },
+      'kokura' => { name: '小倉競馬場', latitude: 33.8428, longitude: 130.8750 }
+    }.freeze
+
+    DEFAULT_THRESHOLDS = {
+      precipitation_probability: 60,
+      precipitation: 5.0,
+      wind_speed: 12.0,
+      temperature_high: 35.0,
+      temperature_low: 0.0
+    }.freeze
+
+    attr_reader :api_endpoint, :thresholds
+
+    def initialize(api_endpoint: DEFAULT_API_ENDPOINT, thresholds: {})
+      @api_endpoint = api_endpoint
+      @thresholds = DEFAULT_THRESHOLDS.merge(thresholds)
+    end
+
+    def monitor(keys = RACECOURSES.keys)
+      keys.map { |key| weather_for(key) }
+    end
+
+    def alerts(keys = RACECOURSES.keys)
+      monitor(keys).select { |weather| weather[:alerts].any? }
+    end
+
+    def weather_for(key)
+      racecourse = racecourse_for(key)
+      daily = fetch_daily_forecast(racecourse)
+      forecast = daily_forecast_for(daily, 0)
+
+      racecourse.merge(
+        key: key.to_s,
+        forecast_date: forecast[:date],
+        weather_code: forecast[:weather_code],
+        precipitation_probability: forecast[:precipitation_probability],
+        precipitation: forecast[:precipitation],
+        wind_speed: forecast[:wind_speed],
+        temperature_max: forecast[:temperature_max],
+        temperature_min: forecast[:temperature_min],
+        alerts: alerts_for(forecast)
+      )
+    end
+
+    private
+
+    def racecourse_for(key)
+      RACECOURSES.fetch(key.to_s) do
+        raise ArgumentError, "unknown racecourse: #{key}"
+      end
+    end
+
+    def fetch_daily_forecast(racecourse)
+      uri = URI(api_endpoint)
+      params = {
+        latitude: racecourse[:latitude],
+        longitude: racecourse[:longitude],
+        daily: 'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,wind_speed_10m_max',
+        timezone: 'Asia/Tokyo',
+        forecast_days: 1
+      }
+      uri.query = URI.encode_www_form(params)
+
+      response = Net::HTTP.get_response(uri)
+      unless response.is_a?(Net::HTTPSuccess)
+        raise "weather API request failed: #{response.code} #{response.message}"
+      end
+
+      JSON.parse(response.body).fetch('daily')
+    end
+
+    def daily_forecast_for(daily, index)
+      {
+        date: daily.fetch('time').fetch(index),
+        weather_code: daily.fetch('weather_code').fetch(index),
+        temperature_max: daily.fetch('temperature_2m_max').fetch(index),
+        temperature_min: daily.fetch('temperature_2m_min').fetch(index),
+        precipitation: daily.fetch('precipitation_sum').fetch(index),
+        precipitation_probability: daily.fetch('precipitation_probability_max').fetch(index),
+        wind_speed: daily.fetch('wind_speed_10m_max').fetch(index)
+      }
+    end
+
+    def alerts_for(forecast)
+      [].tap do |alerts|
+        alerts << :precipitation_probability if forecast[:precipitation_probability].to_f >= thresholds[:precipitation_probability]
+        alerts << :precipitation if forecast[:precipitation].to_f >= thresholds[:precipitation]
+        alerts << :wind_speed if forecast[:wind_speed].to_f >= thresholds[:wind_speed]
+        alerts << :temperature_high if forecast[:temperature_max].to_f >= thresholds[:temperature_high]
+        alerts << :temperature_low if forecast[:temperature_min].to_f <= thresholds[:temperature_low]
+      end
+    end
+  end
+end

--- a/spec/amazon_order/racecourse_weather_monitor_spec.rb
+++ b/spec/amazon_order/racecourse_weather_monitor_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.describe AmazonOrder::RacecourseWeatherMonitor do
+  let(:daily_response) do
+    {
+      'daily' => {
+        'time' => ['2026-07-14'],
+        'weather_code' => [61],
+        'temperature_2m_max' => [36.2],
+        'temperature_2m_min' => [24.1],
+        'precipitation_sum' => [8.4],
+        'precipitation_probability_max' => [70],
+        'wind_speed_10m_max' => [13.5]
+      }
+    }
+  end
+
+  before do
+    response = double('response', body: JSON.dump(daily_response), code: '200', message: 'OK')
+    allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+    allow(Net::HTTP).to receive(:get_response).and_return(response)
+  end
+
+  describe '#weather_for' do
+    it 'returns weather details and threshold alerts for a racecourse' do
+      weather = described_class.new.weather_for(:tokyo)
+
+      expect(weather).to include(
+        key: 'tokyo',
+        name: '東京競馬場',
+        forecast_date: '2026-07-14',
+        weather_code: 61,
+        precipitation_probability: 70,
+        precipitation: 8.4,
+        wind_speed: 13.5,
+        temperature_max: 36.2,
+        temperature_min: 24.1
+      )
+      expect(weather[:alerts]).to contain_exactly(
+        :precipitation_probability,
+        :precipitation,
+        :wind_speed,
+        :temperature_high
+      )
+    end
+
+    it 'requests the Open-Meteo daily forecast for the racecourse coordinates' do
+      described_class.new.weather_for('kyoto')
+
+      expect(Net::HTTP).to have_received(:get_response) do |requested_uri|
+        query = URI.decode_www_form(requested_uri.query).to_h
+        expect(requested_uri.to_s).to start_with(described_class::DEFAULT_API_ENDPOINT)
+        expect(query['latitude']).to eq('34.9069')
+        expect(query['longitude']).to eq('135.7247')
+        expect(query['timezone']).to eq('Asia/Tokyo')
+        expect(query['forecast_days']).to eq('1')
+      end
+    end
+
+    it 'raises a useful error for unknown racecourses' do
+      expect { described_class.new.weather_for(:unknown) }
+        .to raise_error(ArgumentError, 'unknown racecourse: unknown')
+    end
+  end
+
+  describe '#alerts' do
+    it 'filters monitored racecourses to entries that have alerts' do
+      monitor = described_class.new(thresholds: { precipitation_probability: 80, precipitation: 10, wind_speed: 20, temperature_high: 40 })
+      expect(monitor.alerts([:tokyo])).to be_empty
+
+      monitor = described_class.new(thresholds: { precipitation_probability: 60 })
+      expect(monitor.alerts([:tokyo]).map { |weather| weather[:key] }).to eq(['tokyo'])
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide a lightweight way to monitor daily weather for JRA racecourses and surface locations that exceed configurable safety thresholds. 
- Use a public forecast provider so callers can programmatically check precipitation, wind, and temperature risks for race-day decisions.

### Description
- Add `AmazonOrder::RacecourseWeatherMonitor` in `lib/amazon_order/racecourse_weather_monitor.rb` that queries the Open-Meteo daily forecast, maps fields, and evaluates threshold-based alerts. 
- Include built-in coordinates and keys for 10 JRA racecourses and default thresholds in `DEFAULT_THRESHOLDS` so behavior is sensible out of the box. 
- Wire the new class into the gem by adding `require "amazon_order/racecourse_weather_monitor"` to `lib/amazon_order.rb`. 
- Add `spec/amazon_order/racecourse_weather_monitor_spec.rb` covering forecast parsing, API request parameters, unknown racecourse error, and alert filtering, and document usage in `README.md`.

### Testing
- `ruby -c` syntax checks for `lib/amazon_order.rb`, `lib/amazon_order/racecourse_weather_monitor.rb`, and the spec file all passed. 
- Ran a runtime smoke test with `ruby -Ilib` while stubbing `Net::HTTP.get_response` which exercised `weather_for(:tokyo)` and validated returned fields and alerts, and it succeeded. 
- Attempting full `bundle install` and `bundle exec rspec` was blocked: `bundle install` failed due to `rubygems.org` returning `403 Forbidden`, and the `rspec` executable was therefore unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55e7f4d2348332a85116e7fc0bd25e)