### PR TITLE
Improve order details parse errors

### DIFF
--- a/lib/amazon_order/parsers/base.rb
+++ b/lib/amazon_order/parsers/base.rb
@@ -50,20 +50,18 @@ module AmazonOrder
           "selector=#{selector.inspect}",
           "index=#{index}",
           "source_path=#{source_path.inspect}",
-          "node=#{short_node_snapshot}"
+          "node_html=#{node_html_snapshot}"
         ].compact.join(', ')
 
         raise ParseError, message
       end
 
-      def short_node_snapshot
-        snapshot = if @node.respond_to?(:to_html)
+      def node_html_snapshot
+        if @node.respond_to?(:to_html)
           @node.to_html
         else
-          @node.text
+          @node.text.to_s
         end
-
-        snapshot.to_s.gsub(/\s+/, ' ').strip[0, 500]
       end
     end
   end

--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -19,7 +19,12 @@ module AmazonOrder
       end
 
       def order_details_path
-        @_order_details_path ||= @node.css('.order-header .a-col-right .a-row')[1].css('a.a-link-normal')[0].attr('href')
+        @_order_details_path ||= begin
+          details_row = required_node('.order-header .a-col-right .a-row', index: 1, context: 'order_details_path')
+          details_link = details_row.css('a.a-link-normal')[0] || raise_parse_error(selector: 'a.a-link-normal', index: 0, context: 'order_details_path')
+
+          details_link.attr('href')
+        end
       end
 
       def order_type

--- a/spec/amazon_order/parsers/order_spec.rb
+++ b/spec/amazon_order/parsers/order_spec.rb
@@ -27,6 +27,34 @@ RSpec.shared_examples "generic order specs" do
 end
 
 describe 'AmazonOrder::Parsers' do
+
+  describe AmazonOrder::Parsers::NormalOrder do
+    describe '#order_details_path' do
+      it 'raises ParseError with the order node HTML when the details link is missing' do
+        node = Nokogiri::HTML.fragment(<<~HTML)
+          <div class="order-card">
+            <div class="order-header">
+              <div class="a-col-right">
+                <div class="a-row">ORDER # 123-1234567-1234567</div>
+                <div class="a-row"><span>No details link</span></div>
+              </div>
+            </div>
+          </div>
+        HTML
+        order = described_class.new(node, source_path: 'spec/fixtures/missing-details.html')
+
+        expect {
+          order.order_details_path
+        }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
+          expect(error.message).to include('AmazonOrder::Parsers::NormalOrder failed to parse order_details_path')
+          expect(error.message).to include('selector="a.a-link-normal"')
+          expect(error.message).to include('source_path="spec/fixtures/missing-details.html"')
+          expect(error.message).to include('node_html=<div class="order-card">')
+          expect(error.message).to include('<span>No details link</span>')
+        }
+      end
+    end
+  end
   let(:parser) { AmazonOrder::Parser.new(filepath) }
   let(:order) { parser.orders[index_of_order] }
 


### PR DESCRIPTION
### Motivation
- Prevent a `NoMethodError` when `NormalOrder#order_details_path` tries to call `attr` on a missing link and surface a parser-specific error instead. 
- Provide the offending order HTML in parse error messages to make debugging missing or malformed nodes easier. 
- Add a spec to cover the missing order details link case so regressions are detected.

### Description
- Update `NormalOrder#order_details_path` to use `required_node` and explicitly raise a parser error via `raise_parse_error` when the details link is missing, returning the link `href` when present (`lib/amazon_order/parsers/normal_order.rb`).
- Replace the old `short_node_snapshot` with `node_html_snapshot` and include `node_html=...` in parse error messages to print the node HTML using `@node.to_html` when available (`lib/amazon_order/parsers/base.rb`).
- Add an RSpec example asserting that a missing details link raises `AmazonOrder::Parsers::ParseError` and that the error message contains the `node_html` and relevant context (`spec/amazon_order/parsers/order_spec.rb`).

### Testing
- Ran syntax checks with `ruby -c` for `lib/amazon_order/parsers/base.rb`, `lib/amazon_order/parsers/normal_order.rb`, and `spec/amazon_order/parsers/order_spec.rb`, which all reported `Syntax OK`.
- Attempted to run specs with `bundle exec rspec ...` but the `rspec` executable was not available because `bundle install` failed with a RubyGems `403 "Forbidden"` while fetching dependencies, so automated specs could not be executed.
- Attempted a quick runtime reproduction with `ruby -Ilib -e ...` but it failed due to missing runtime gems (`amazon_auth`/`nokogiri`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5634a85e908332a9501a33e4810f53)