### PR TITLE
Find order-details links anywhere in order node and improve parse selector

### DIFF
--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -21,7 +21,7 @@ module AmazonOrder
       def order_details_path
         @_order_details_path ||= begin
           details_link = @node.css('a[href]').find { |link| order_details_link?(link) } ||
-                         raise_parse_error(selector: 'a[href*=order-details]', index: 0, context: 'order_details_path')
+                         raise_parse_error(selector: 'a[href*=order-details], a[href^="/your-orders/search"]', index: 0, context: 'order_details_path')
 
           details_link.attr('href')
         end
@@ -52,7 +52,11 @@ module AmazonOrder
       def order_details_link?(link)
         href = link.attr('href').to_s
 
-        href.include?('/order-details') || href.include?('order-details?')
+        href.include?('/order-details') || href.include?('order-details?') || order_search_link?(href)
+      end
+
+      def order_search_link?(href)
+        href.start_with?('/your-orders/search?') && href.include?('search=')
       end
 
     end

--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -20,8 +20,8 @@ module AmazonOrder
 
       def order_details_path
         @_order_details_path ||= begin
-          details_row = required_node('.order-header .a-col-right .a-row', index: 1, context: 'order_details_path')
-          details_link = details_row.css('a.a-link-normal')[0] || raise_parse_error(selector: 'a.a-link-normal', index: 0, context: 'order_details_path')
+          details_link = @node.css('a[href]').find { |link| order_details_link?(link) } ||
+                         raise_parse_error(selector: 'a[href*=order-details]', index: 0, context: 'order_details_path')
 
           details_link.attr('href')
         end
@@ -45,6 +45,14 @@ module AmazonOrder
         super do |hash|
           hash.merge!(products: products.map(&:to_hash))
         end
+      end
+
+      private
+
+      def order_details_link?(link)
+        href = link.attr('href').to_s
+
+        href.include?('/order-details') || href.include?('order-details?')
       end
 
     end

--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -21,7 +21,7 @@ module AmazonOrder
       def order_details_path
         @_order_details_path ||= begin
           details_link = @node.css('a[href]').find { |link| order_details_link?(link) } ||
-                         raise_parse_error(selector: 'a[href*=order-details], a[href^="/your-orders/search"]', index: 0, context: 'order_details_path')
+                         raise_parse_error(selector: 'a[href*=order-details], a[href*=order-summary.html], a[href^="/your-orders/search"]', index: 0, context: 'order_details_path')
 
           details_link.attr('href')
         end
@@ -52,11 +52,14 @@ module AmazonOrder
       def order_details_link?(link)
         href = link.attr('href').to_s
 
-        href.include?('/order-details') || href.include?('order-details?') || order_search_link?(href)
+        href.include?('/order-details') ||
+          href.include?('order-details?') ||
+          href.include?('order-summary.html') ||
+          order_search_link?(href)
       end
 
       def order_search_link?(href)
-        href.start_with?('/your-orders/search?') && href.include?('search=')
+        href.start_with?('/your-orders/search') && href.include?('search=')
       end
 
     end

--- a/spec/amazon_order/parsers/order_spec.rb
+++ b/spec/amazon_order/parsers/order_spec.rb
@@ -59,6 +59,32 @@ describe 'AmazonOrder::Parsers' do
         expect(order.order_details_path).to eq('/your-orders/order-details?orderID=000-0000000-0000000&ref=ppx_yo2ov_dt_b_fed_veo')
       end
 
+      it 'finds a search-based order details link' do
+        node = Nokogiri::HTML.fragment(<<~HTML)
+          <div class="order-card">
+            <div class="order-header">
+              <div class="a-col-right">
+                <div class="a-row">注文番号 000-0000000-0000000</div>
+                <div class="a-row">
+                  <a class="a-link-normal" href="/your-orders/search?search=digital-order-token&amp;ref=ppx_yo2ov_dt_b_fed_dss_shell_od_hz_search">
+                    注文内容を表示
+                  </a>
+                  <a class="a-link-normal" href="/your-orders/invoice/popover?orderId=digital-order-token&amp;ref_=fed_invoice_ajax_dss">
+                    請求書
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="product-image">
+              <a class="a-link-normal" href="/products/example-item?ref=ppx_yo2ov_dt_b_fed_asin_title">Example item</a>
+            </div>
+          </div>
+        HTML
+        order = described_class.new(node)
+
+        expect(order.order_details_path).to eq('/your-orders/search?search=digital-order-token&ref=ppx_yo2ov_dt_b_fed_dss_shell_od_hz_search')
+      end
+
       it 'raises ParseError with the order node HTML when the details link is missing' do
         node = Nokogiri::HTML.fragment(<<~HTML)
           <div class="order-card">
@@ -76,7 +102,7 @@ describe 'AmazonOrder::Parsers' do
           order.order_details_path
         }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
           expect(error.message).to include('AmazonOrder::Parsers::NormalOrder failed to parse order_details_path')
-          expect(error.message).to include('selector="a[href*=order-details]"')
+          expect(error.message).to include('selector="a[href*=order-details], a[href^=\"/your-orders/search\"]"')
           expect(error.message).to include('source_path="spec/fixtures/missing-details.html"')
           expect(error.message).to include('node_html=<div class="order-card">')
           expect(error.message).to include('<span>No details link</span>')

--- a/spec/amazon_order/parsers/order_spec.rb
+++ b/spec/amazon_order/parsers/order_spec.rb
@@ -66,7 +66,7 @@ describe 'AmazonOrder::Parsers' do
               <div class="a-col-right">
                 <div class="a-row">注文番号 000-0000000-0000000</div>
                 <div class="a-row">
-                  <a class="a-link-normal" href="/your-orders/search?search=digital-order-token&amp;ref=ppx_yo2ov_dt_b_fed_dss_shell_od_hz_search">
+                  <a class="a-link-normal" href="/your-orders/search/ref=ppx_yo2ov_dt_b_search?ref_=example&amp;search=digital-order-token">
                     注文内容を表示
                   </a>
                   <a class="a-link-normal" href="/your-orders/invoice/popover?orderId=digital-order-token&amp;ref_=fed_invoice_ajax_dss">
@@ -82,7 +82,29 @@ describe 'AmazonOrder::Parsers' do
         HTML
         order = described_class.new(node)
 
-        expect(order.order_details_path).to eq('/your-orders/search?search=digital-order-token&ref=ppx_yo2ov_dt_b_fed_dss_shell_od_hz_search')
+        expect(order.order_details_path).to eq('/your-orders/search/ref=ppx_yo2ov_dt_b_search?ref_=example&search=digital-order-token')
+      end
+
+      it 'finds a digital order summary details link' do
+        node = Nokogiri::HTML.fragment(<<~HTML)
+          <div class="order-card">
+            <div class="order-info">
+              <div class="a-col-right">
+                <div class="a-row">
+                  <a class="a-link-normal yohtmlc-order-details-link" href="/gp/digital/your-account/order-summary.html/ref=ppx_yo_dt_b_dor?ie=UTF8&amp;orderID=digital-order-token">
+                    注文内容を表示
+                  </a>
+                  <a class="a-link-normal" href="/gp/digital/your-account/order-summary.html/ref=ppx_yo_dt_b_dpi?ie=UTF8&amp;orderID=digital-order-token&amp;print=1">
+                    印刷
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        HTML
+        order = described_class.new(node)
+
+        expect(order.order_details_path).to eq('/gp/digital/your-account/order-summary.html/ref=ppx_yo_dt_b_dor?ie=UTF8&orderID=digital-order-token')
       end
 
       it 'raises ParseError with the order node HTML when the details link is missing' do
@@ -102,7 +124,7 @@ describe 'AmazonOrder::Parsers' do
           order.order_details_path
         }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
           expect(error.message).to include('AmazonOrder::Parsers::NormalOrder failed to parse order_details_path')
-          expect(error.message).to include('selector="a[href*=order-details], a[href^=\"/your-orders/search\"]"')
+          expect(error.message).to include('selector="a[href*=order-details], a[href*=order-summary.html], a[href^=\"/your-orders/search\"]"')
           expect(error.message).to include('source_path="spec/fixtures/missing-details.html"')
           expect(error.message).to include('node_html=<div class="order-card">')
           expect(error.message).to include('<span>No details link</span>')

--- a/spec/amazon_order/parsers/order_spec.rb
+++ b/spec/amazon_order/parsers/order_spec.rb
@@ -30,12 +30,41 @@ describe 'AmazonOrder::Parsers' do
 
   describe AmazonOrder::Parsers::NormalOrder do
     describe '#order_details_path' do
+      it 'finds an order details link outside the order header actions row' do
+        node = Nokogiri::HTML.fragment(<<~HTML)
+          <div class="order-card">
+            <div class="order-header">
+              <div class="a-col-right">
+                <div class="a-row">注文番号 000-0000000-0000000</div>
+                <div class="a-row"></div>
+              </div>
+            </div>
+            <div class="product-image">
+              <a class="a-link-normal" href="/products/example-item?ref=ppx_yo2ov_dt_b_fed_asin_title">Example item</a>
+            </div>
+            <ul class="yohtmlc-shipment-level-connections">
+              <li>
+                <a href="/hz/pwo?orderID=000-0000000-0000000" class="a-button-text">注文に関する問題</a>
+              </li>
+              <li>
+                <a href="/your-orders/order-details?orderID=000-0000000-0000000&amp;ref=ppx_yo2ov_dt_b_fed_veo" class="a-button-text">
+                  注文内容の表示と変更
+                </a>
+              </li>
+            </ul>
+          </div>
+        HTML
+        order = described_class.new(node)
+
+        expect(order.order_details_path).to eq('/your-orders/order-details?orderID=000-0000000-0000000&ref=ppx_yo2ov_dt_b_fed_veo')
+      end
+
       it 'raises ParseError with the order node HTML when the details link is missing' do
         node = Nokogiri::HTML.fragment(<<~HTML)
           <div class="order-card">
             <div class="order-header">
               <div class="a-col-right">
-                <div class="a-row">ORDER # 123-1234567-1234567</div>
+                <div class="a-row">注文番号 000-0000000-0000000</div>
                 <div class="a-row"><span>No details link</span></div>
               </div>
             </div>
@@ -47,7 +76,7 @@ describe 'AmazonOrder::Parsers' do
           order.order_details_path
         }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
           expect(error.message).to include('AmazonOrder::Parsers::NormalOrder failed to parse order_details_path')
-          expect(error.message).to include('selector="a.a-link-normal"')
+          expect(error.message).to include('selector="a[href*=order-details]"')
           expect(error.message).to include('source_path="spec/fixtures/missing-details.html"')
           expect(error.message).to include('node_html=<div class="order-card">')
           expect(error.message).to include('<span>No details link</span>')


### PR DESCRIPTION
### Motivation

- The order details link was only looked up inside the header actions row so orders that place the link elsewhere failed to parse; the change aims to locate the correct link anywhere within the order node.
- The parse error message was updated to reflect the new selector strategy when the details link is missing.

### Description

- `NormalOrder#order_details_path` now scans all `a[href]` elements in the order node and selects the first link that matches `order_details_link?` instead of only checking the header actions row. 
- Added a private helper `order_details_link?` that checks the `href` for `/order-details` or `order-details?`.
- The `raise_parse_error` selector argument was changed to `'a[href*=order-details]'` to match the new lookup behavior.
- Specs were updated to add a case where the order details link is outside the header and to adjust the expected parse error message selector.

### Testing

- Ran the order parser specs with `bundle exec rspec spec/amazon_order/parsers/order_spec.rb` and the updated examples passed.
- The change is covered by the new unit test that verifies finding an order details link outside the header and the updated error expectation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56388c20f4833290e84cce918f673b)