### PR TITLE
Handle Audible order detail links

### DIFF
--- a/lib/amazon_order/parsers/normal_order.rb
+++ b/lib/amazon_order/parsers/normal_order.rb
@@ -21,7 +21,7 @@ module AmazonOrder
       def order_details_path
         @_order_details_path ||= begin
           details_link = @node.css('a[href]').find { |link| order_details_link?(link) } ||
-                         raise_parse_error(selector: 'a[href*=order-details], a[href*=order-summary.html], a[href^="/your-orders/search"]', index: 0, context: 'order_details_path')
+                         raise_parse_error(selector: 'a[href*=order-details], a[href*=order-detail], a[href*=order-summary.html], a[href^="/your-orders/search"]', index: 0, context: 'order_details_path')
 
           details_link.attr('href')
         end
@@ -54,6 +54,7 @@ module AmazonOrder
 
         href.include?('/order-details') ||
           href.include?('order-details?') ||
+          href.include?('order-detail?') ||
           href.include?('order-summary.html') ||
           order_search_link?(href)
       end

--- a/spec/amazon_order/parsers/order_spec.rb
+++ b/spec/amazon_order/parsers/order_spec.rb
@@ -107,6 +107,26 @@ describe 'AmazonOrder::Parsers' do
         expect(order.order_details_path).to eq('/gp/digital/your-account/order-summary.html/ref=ppx_yo_dt_b_dor?ie=UTF8&orderID=digital-order-token')
       end
 
+      it 'finds an Audible order detail link' do
+        node = Nokogiri::HTML.fragment(<<~HTML)
+          <div class="order-card">
+            <div class="order-header">
+              <div class="a-col-right">
+                <div class="a-row">注文番号 D01-0000000-0000000</div>
+                <div class="a-row">
+                  <a class="a-link-normal" href="https://www.audible.co.jp/order-detail?orderNumber=audible-order-token&amp;orderType=REGULAR">
+                    注文内容を表示 <span class="a-color-secondary">(Audible.co.jp)</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        HTML
+        order = described_class.new(node)
+
+        expect(order.order_details_path).to eq('https://www.audible.co.jp/order-detail?orderNumber=audible-order-token&orderType=REGULAR')
+      end
+
       it 'raises ParseError with the order node HTML when the details link is missing' do
         node = Nokogiri::HTML.fragment(<<~HTML)
           <div class="order-card">
@@ -124,7 +144,7 @@ describe 'AmazonOrder::Parsers' do
           order.order_details_path
         }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
           expect(error.message).to include('AmazonOrder::Parsers::NormalOrder failed to parse order_details_path')
-          expect(error.message).to include('selector="a[href*=order-details], a[href*=order-summary.html], a[href^=\"/your-orders/search\"]"')
+          expect(error.message).to include('selector="a[href*=order-details], a[href*=order-detail], a[href*=order-summary.html], a[href^=\"/your-orders/search\"]"')
           expect(error.message).to include('source_path="spec/fixtures/missing-details.html"')
           expect(error.message).to include('node_html=<div class="order-card">')
           expect(error.message).to include('<span>No details link</span>')


### PR DESCRIPTION
### Motivation

- Fix parse failures when order cards include Audible-style links like `https://www.audible.co.jp/order-detail?...` that were not recognized as order detail links.

### Description

- Update `AmazonOrder::Parsers::NormalOrder#order_details_link?` to recognize the singular `order-detail?` pattern in addition to existing `order-details` and `order-summary.html` checks.
- Include the `order-detail` pattern in the `raise_parse_error` selector message used when an order details link is not found.
- Add a spec that verifies an Audible `order-detail` URL is returned by `order_details_path` and update the missing-details spec expectation to match the new selector string.

### Testing

- Ran `ruby -c lib/amazon_order/parsers/normal_order.rb` and `ruby -c spec/amazon_order/parsers/order_spec.rb`, both returned syntax OK.
- Attempted `bundle install`, which failed due to `rubygems.org` returning HTTP 403 so dependencies could not be installed.
- `bundle exec rspec spec/amazon_order/parsers/order_spec.rb` could not be executed because the test environment setup (`bundle install`) was blocked, so specs were not run end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5670ea871c8332ad79cd6d5b7d7ce8)