### PR TITLE
Remove blank lines from parser HTML snapshots

### DIFF
--- a/lib/amazon_order/parsers/base.rb
+++ b/lib/amazon_order/parsers/base.rb
@@ -57,11 +57,13 @@ module AmazonOrder
       end
 
       def node_html_snapshot
-        if @node.respond_to?(:to_html)
-          @node.to_html
-        else
-          @node.text.to_s
-        end
+        snapshot = if @node.respond_to?(:to_html)
+                     @node.to_html
+                   else
+                     @node.text.to_s
+                   end
+
+        snapshot.lines.reject { |line| line.strip.empty? }.join
       end
     end
   end

--- a/spec/amazon_order/parsers/base_spec.rb
+++ b/spec/amazon_order/parsers/base_spec.rb
@@ -21,5 +21,26 @@ RSpec.describe AmazonOrder::Parsers::Base do
         expect(error.message).to include('order-card')
       }
     end
+
+    it 'removes blank lines from the node HTML snapshot' do
+      node_with_blank_lines = Nokogiri::HTML.fragment(<<~HTML)
+        <div class="order-card">
+
+          <span class="present">ok</span>
+
+        </div>
+      HTML
+      parser = described_class.new(node_with_blank_lines)
+
+      expect {
+        parser.required_node('.missing', context: 'order_total')
+      }.to raise_error(AmazonOrder::Parsers::ParseError) { |error|
+        html = error.message[/node_html=(.*)\z/m, 1]
+
+        expect(html).to include('<div class="order-card">')
+        expect(html).to include('<span class="present">ok</span>')
+        expect(html).not_to include("\n\n")
+      }
+    end
   end
 end


### PR DESCRIPTION
### Motivation
- Improve readability and compactness of `node_html` included in `ParseError` messages by removing superfluous blank lines from HTML snapshots.
- Add a spec to ensure blank lines are removed while preserving the meaningful HTML content.

### Description
- Update `node_html_snapshot` in `lib/amazon_order/parsers/base.rb` to normalize the snapshot and remove empty lines via `snapshot.lines.reject { |line| line.strip.empty? }.join`.
- Add a spec `spec/amazon_order/parsers/base_spec.rb` that constructs a fragment containing blank lines and asserts the `node_html` in the raised `ParseError` does not include consecutive blank lines and still contains the expected HTML.

### Testing
- Ran `ruby -c lib/amazon_order/parsers/base.rb` and the syntax check succeeded.
- Ran `ruby -c spec/amazon_order/parsers/base_spec.rb` and the syntax check succeeded.
- Attempted `bundle exec rspec spec/amazon_order/parsers/base_spec.rb`, but the `rspec` executable was not available so the spec run was blocked.
- Attempted `bundle install` to install dependencies, but fetching from Rubygems failed with a `403 Forbidden`, so the test suite could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5670b9b9c483328d1363f17ad68b5f)