### PR TITLE
Add opt-in order detail page fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ separately continues to use all previously downloaded order-list pages.
 With `debug: true`, detail downloads log the order number, URL, and progress
 such as `(7/20)`. Already-saved orders are excluded from that progress total.
 
-If sign-in returns without reaching the order-history page, the client revisits
-the Amazon origin and retries up to three times. Set `sign_in_attempts` to
-change the maximum number of attempts (for example, `sign_in_attempts: 1` to
-disable retries).
+`client.sign_in` retries up to three times when the underlying `amazon_auth`
+sign-in returns false, raises an error, or leaves the browser on an
+authentication page. Before each retry it revisits the Amazon origin. Set
+`sign_in_attempts` to change the maximum number of attempts (for example,
+`sign_in_attempts: 1` to disable retries). Order fetching additionally verifies
+that the successfully authenticated browser reaches the order-history page.
 
 Once `fetch_amazon_orders` succeeds, you can load orders information of downloaded pages anytime.
 (You don't need to fetch pages with launching browser every time.)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ order-list pages downloaded by that `fetch_amazon_orders` run are considered.
 For example, `limit: 2` fetches details for those two new list pages, not every
 historical list page already under `tmp/orders`. Calling `fetch_order_details`
 separately continues to use all previously downloaded order-list pages.
+With `debug: true`, detail downloads log the order number, URL, and progress
+such as `(7/20)`. Already-saved orders are excluded from that progress total.
 
 Once `fetch_amazon_orders` succeeds, you can load orders information of downloaded pages anytime.
 (You don't need to fetch pages with launching browser every time.)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Detail HTML files are stored under `tmp/orders/details` (relative to
 `Capybara.save_path`). **These files can contain names, addresses, purchase
 history, and other personal information. Store and share them securely.**
 
+With the opt-in `fetch_order_details: true`, only orders found in the
+order-list pages downloaded by that `fetch_amazon_orders` run are considered.
+For example, `limit: 2` fetches details for those two new list pages, not every
+historical list page already under `tmp/orders`. Calling `fetch_order_details`
+separately continues to use all previously downloaded order-list pages.
+
 Once `fetch_amazon_orders` succeeds, you can load orders information of downloaded pages anytime.
 (You don't need to fetch pages with launching browser every time.)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ client.fetch_orders_for_year(year: 2016)
 
 # Fetch all pages of specified year
 client = AmazonOrder::Client.new(limit: nil)
-client.sign_in
+client.sign_in_with_retry
 client.go_to_amazon_order_page
 client.fetch_orders_for_year(year: 2015)
 ```
@@ -81,7 +81,7 @@ stop the remaining downloads by default (`continue_on_error: false` makes the
 first failure abort the operation).
 
 ```ruby
-client.sign_in
+client.sign_in_with_retry
 client.go_to_amazon_order_page
 client.fetch_order_details
 client.fetch_order_details(force: true, continue_on_error: false)
@@ -105,7 +105,7 @@ separately continues to use all previously downloaded order-list pages.
 With `debug: true`, detail downloads log the order number, URL, and progress
 such as `(7/20)`. Already-saved orders are excluded from that progress total.
 
-`client.sign_in` retries up to three times when the underlying `amazon_auth`
+`client.sign_in_with_retry` retries up to three times when the underlying `amazon_auth`
 sign-in returns false, raises an error, or leaves the browser on an
 authentication page. Before each retry it revisits the Amazon origin. Set
 `sign_in_attempts` to change the maximum number of attempts (for example,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ client.fetch_order_details
 client.fetch_order_details(force: true, continue_on_error: false)
 ```
 
+Standalone `fetch_order_details` verifies the authenticated order-history
+session (using the same sign-in retry behavior) before loading saved lists or
+requesting any detail page. It stops immediately if authentication still fails.
+If authentication expires during the detail loop, fetching also stops even
+when `continue_on_error` is enabled; authentication failures are never skipped.
+
 Detail HTML files are stored under `tmp/orders/details` (relative to
 `Capybara.save_path`). **These files can contain names, addresses, purchase
 history, and other personal information. Store and share them securely.**

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ In console
 require 'amazon_order'
 client = AmazonOrder::Client.new(keep_cookie: true, verbose: true, limit: 10)
 client.fetch_amazon_orders
+# Fetch order-list pages and then each order detail (opt-in)
+client = AmazonOrder::Client.new(fetch_order_details: true)
+client.fetch_amazon_orders
 # Fetch orders of specified year
 client.fetch_orders_for_year(year: 2016)
 
@@ -70,6 +73,23 @@ client.fetch_orders_for_year(year: 2015)
 
 Downloaded pages will be stored into `tmp/orders` directory.  
 `tmp` comes from `Capybara.save_path`.  
+
+Order details can also be fetched separately after the order-list pages have
+been downloaded. Existing details are skipped by order number by default; pass
+`force: true` to download them again. A failed order is logged and does not
+stop the remaining downloads by default (`continue_on_error: false` makes the
+first failure abort the operation).
+
+```ruby
+client.sign_in
+client.go_to_amazon_order_page
+client.fetch_order_details
+client.fetch_order_details(force: true, continue_on_error: false)
+```
+
+Detail HTML files are stored under `tmp/orders/details` (relative to
+`Capybara.save_path`). **These files can contain names, addresses, purchase
+history, and other personal information. Store and share them securely.**
 
 Once `fetch_amazon_orders` succeeds, you can load orders information of downloaded pages anytime.
 (You don't need to fetch pages with launching browser every time.)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ separately continues to use all previously downloaded order-list pages.
 With `debug: true`, detail downloads log the order number, URL, and progress
 such as `(7/20)`. Already-saved orders are excluded from that progress total.
 
+If sign-in returns without reaching the order-history page, the client revisits
+the Amazon origin and retries up to three times. Set `sign_in_attempts` to
+change the maximum number of attempts (for example, `sign_in_attempts: 1` to
+disable retries).
+
 Once `fetch_amazon_orders` succeeds, you can load orders information of downloaded pages anytime.
 (You don't need to fetch pages with launching browser every time.)
 

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module AmazonOrder
   class Client
     include AmazonAuth::CommonExtension
@@ -36,6 +38,51 @@ module AmazonOrder
       year_to.to_i.downto(year_from.to_i) do |year|
         fetch_orders_for_year(year: year)
       end
+      fetch_order_details if options.fetch(:fetch_order_details, false)
+    end
+
+    # Fetches each order's detail page once. Order numbers, rather than URLs,
+    # identify orders because Amazon adds non-stable reference parameters to
+    # detail links.
+    def fetch_order_details(fetch_options = {})
+      force = fetch_options.fetch(:force, options.fetch(:force_order_details, false))
+      continue_on_error = fetch_options.fetch(
+        :continue_on_error,
+        options.fetch(:continue_on_detail_error, true)
+      )
+      origin = order_history_origin
+      seen = {}
+
+      load_amazon_orders.each do |order|
+        order_number = order.order_number.to_s
+        path = order.order_details_path.to_s
+        next if order_number.empty? || path.empty? || seen[order_number]
+        seen[order_number] = true
+
+        filename_order_number = sanitized_order_number(order_number)
+        if !force && detail_already_saved?(filename_order_number)
+          log "Skipping saved order detail: order=#{order_number} url=#{path}"
+          next
+        end
+
+        url = absolute_order_details_url(path, origin)
+        begin
+          session.visit(url)
+          wait_for_selector('body')
+          if authentication_page?
+            raise "authentication page was displayed"
+          end
+
+          filename = [
+            'order-detail', filename_order_number,
+            Time.current.strftime('%Y%m%d%H%M%S%L')
+          ].join('-') + '.html'
+          session.save_page(File.join(base_dir, 'details', filename))
+        rescue => e
+          log "Failed to fetch order detail: order=#{order_number} url=#{url} error=#{e.message}"
+          raise unless continue_on_error
+        end
+      end
     end
 
     def load_amazon_orders
@@ -73,6 +120,7 @@ module AmazonOrder
       link = links_for('a').find{|link| link =~ %r{/order-history} }
       if link.present?
         session.visit link
+        @order_history_origin = url_origin(session.current_url)
       else
         log "Link for order history wasn't found in #{session.current_url}"
       end
@@ -127,6 +175,47 @@ module AmazonOrder
     def next_page_node
       wait_for_selector('.a-pagination .a-selected')
       doc.css('.a-pagination .a-selected ~ .a-normal').css('a').first
+    end
+
+    private
+
+    def order_history_origin
+      @order_history_origin ||= url_origin(session.current_url)
+      raise ArgumentError, 'The order history page URL is required to resolve relative detail links' if @order_history_origin.nil?
+      @order_history_origin
+    end
+
+    def url_origin(url)
+      uri = URI.parse(url.to_s)
+      return nil unless uri.is_a?(URI::HTTP) && uri.host
+      "#{uri.scheme}://#{uri.host}#{uri.port == uri.default_port ? '' : ":#{uri.port}"}"
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def absolute_order_details_url(path, origin)
+      uri = URI.parse(path)
+      uri.is_a?(URI::HTTP) ? uri.to_s : URI.join("#{origin}/", path).to_s
+    end
+
+    def sanitized_order_number(order_number)
+      sanitized = order_number.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+                              .gsub(/[^0-9A-Za-z._-]+/, '_')
+                              .gsub(/\A[._-]+|[._-]+\z/, '')
+      sanitized.empty? ? 'unknown' : sanitized
+    end
+
+    def detail_already_saved?(filename_order_number)
+      pattern = File.join(
+        Capybara.save_path, base_dir, 'details',
+        "order-detail-#{filename_order_number}-*.html"
+      )
+      Dir.glob(pattern).any?
+    end
+
+    def authentication_page?
+      session.current_url.to_s.match?(%r{/(?:ap/)?signin(?:[/?]|$)|/ap/cvf/}) ||
+        doc.css('form[name="signIn"], #ap_email, #ap_password').any?
     end
   end
 end

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -57,6 +57,7 @@ module AmazonOrder
       orders = fetch_options.fetch(:orders) { load_amazon_orders }
       origin = order_history_origin
       seen = {}
+      details_to_fetch = []
 
       orders.each do |order|
         order_number = order.order_number.to_s
@@ -70,8 +71,13 @@ module AmazonOrder
           next
         end
 
-        url = absolute_order_details_url(path, origin)
+        details_to_fetch << [order_number, filename_order_number, absolute_order_details_url(path, origin)]
+      end
+
+      details_to_fetch.each_with_index do |(order_number, filename_order_number, url), index|
+        progress = "(#{index + 1}/#{details_to_fetch.size})"
         begin
+          log "Fetching order detail #{progress}: order=#{order_number} url=#{url}"
           session.visit(url)
           wait_for_selector('body')
           if authentication_page?
@@ -82,9 +88,10 @@ module AmazonOrder
             'order-detail', filename_order_number,
             Time.current.strftime('%Y%m%d%H%M%S%L')
           ].join('-') + '.html'
+          log "Saving order detail #{progress}: order=#{order_number} url=#{url}"
           session.save_page(File.join(base_dir, 'details', filename))
         rescue => e
-          log "Failed to fetch order detail: order=#{order_number} url=#{url} error=#{e.message}"
+          log "Failed to fetch order detail #{progress}: order=#{order_number} url=#{url} error=#{e.message}"
           raise unless continue_on_error
         end
       end

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -2,6 +2,8 @@ require 'uri'
 
 module AmazonOrder
   class Client
+    class AuthenticationError < StandardError; end
+
     include AmazonAuth::CommonExtension
 
     attr_accessor :session, :options
@@ -109,6 +111,10 @@ module AmazonOrder
 
     def sign_in
       @client.sign_in
+      return unless authentication_page?
+
+      raise AuthenticationError,
+        "Amazon sign-in did not complete (current_url=#{session.current_url})"
     end
 
     def go_to_amazon_order_page

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -35,7 +35,7 @@ module AmazonOrder
     end
 
     def fetch_amazon_orders
-      sign_in_and_open_order_history
+      ensure_order_history_session
       fetched_page_paths = year_to.to_i.downto(year_from.to_i).flat_map do |year|
         fetch_orders_for_year(year: year)
       end
@@ -48,6 +48,7 @@ module AmazonOrder
     # identify orders because Amazon adds non-stable reference parameters to
     # detail links.
     def fetch_order_details(fetch_options = {})
+      ensure_order_history_session
       force = fetch_options.fetch(:force, options.fetch(:force_order_details, false))
       continue_on_error = fetch_options.fetch(
         :continue_on_error,
@@ -80,7 +81,7 @@ module AmazonOrder
           session.visit(url)
           wait_for_selector('body')
           if authentication_page?
-            raise "authentication page was displayed"
+            raise AuthenticationError, "authentication page was displayed"
           end
 
           filename = [
@@ -91,7 +92,7 @@ module AmazonOrder
           session.save_page(File.join(base_dir, 'details', filename))
         rescue => e
           log "Failed to fetch order detail #{progress}: order=#{order_number} url=#{url} error=#{e.message}"
-          raise unless continue_on_error
+          raise if e.is_a?(AuthenticationError) || !continue_on_error
         end
       end
     end
@@ -190,6 +191,12 @@ module AmazonOrder
     end
 
     private
+
+    def ensure_order_history_session
+      return true if order_history_page?
+
+      sign_in_and_open_order_history
+    end
 
     def sign_in_and_open_order_history
       max_attempts = options.fetch(:sign_in_attempts, 3).to_i

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -12,6 +12,8 @@ module AmazonOrder
       @options = options
       @client = AmazonAuth::Client.new(@options)
       extend(AmazonAuth::SessionExtension)
+      @amazon_auth_sign_in = method(:sign_in)
+      define_singleton_method(:sign_in) { sign_in_with_retry }
     end
 
     def base_dir
@@ -113,10 +115,6 @@ module AmazonOrder
       @_writer ||= AmazonOrder::Writer.new(file_glob_pattern)
     end
 
-    def sign_in
-      @client.sign_in
-    end
-
     def go_to_amazon_order_page
       return true if order_history_page?
 
@@ -192,6 +190,27 @@ module AmazonOrder
 
     private
 
+    def sign_in_with_retry
+      max_attempts = options.fetch(:sign_in_attempts, 3).to_i
+      max_attempts = 1 if max_attempts < 1
+
+      1.upto(max_attempts) do |attempt|
+        begin
+          result = @amazon_auth_sign_in.call
+          return true if result && !authentication_page?
+          raise AuthenticationError,
+            "Amazon sign-in did not complete (current_url=#{session.current_url})"
+        rescue => e
+          log "Amazon sign-in attempt #{attempt}/#{max_attempts} failed: #{e.message}"
+          raise AuthenticationError, e.message if attempt == max_attempts
+
+          retry_url = url_origin(session.current_url)
+          log "Retrying Amazon sign-in from #{retry_url}"
+          session.visit("#{retry_url}/") if retry_url
+        end
+      end
+    end
+
     def ensure_order_history_session
       return true if order_history_page?
 
@@ -199,24 +218,11 @@ module AmazonOrder
     end
 
     def sign_in_and_open_order_history
-      max_attempts = options.fetch(:sign_in_attempts, 3).to_i
-      max_attempts = 1 if max_attempts < 1
+      sign_in
+      return true if go_to_amazon_order_page
 
-      1.upto(max_attempts) do |attempt|
-        begin
-          sign_in
-          return true if go_to_amazon_order_page
-          raise AuthenticationError,
-            "Amazon order history was not reached (current_url=#{session.current_url})"
-        rescue => e
-          log "Amazon sign-in attempt #{attempt}/#{max_attempts} failed: #{e.message}"
-          raise if attempt == max_attempts
-
-          retry_url = url_origin(session.current_url)
-          log "Retrying Amazon sign-in from #{retry_url}"
-          session.visit("#{retry_url}/") if retry_url
-        end
-      end
+      raise AuthenticationError,
+        "Amazon order history was not reached (current_url=#{session.current_url})"
     end
 
     def order_history_page?

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -114,10 +114,6 @@ module AmazonOrder
 
     def sign_in
       @client.sign_in
-      return unless authentication_page?
-
-      raise AuthenticationError,
-        "Amazon sign-in did not complete (current_url=#{session.current_url})"
     end
 
     def go_to_amazon_order_page

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -35,8 +35,7 @@ module AmazonOrder
     end
 
     def fetch_amazon_orders
-      sign_in
-      go_to_amazon_order_page
+      sign_in_and_open_order_history
       fetched_page_paths = year_to.to_i.downto(year_from.to_i).flat_map do |year|
         fetch_orders_for_year(year: year)
       end
@@ -122,6 +121,8 @@ module AmazonOrder
     end
 
     def go_to_amazon_order_page
+      return true if order_history_page?
+
       if doc.css('.cvf-account-switcher').present?
         log "Account switcher page was displayed"
         session.first('.cvf-account-switcher-profile-details').click
@@ -131,9 +132,11 @@ module AmazonOrder
       if link.present?
         session.visit link
         @order_history_origin = url_origin(session.current_url)
+        return order_history_page?
       else
         log "Link for order history wasn't found in #{session.current_url}"
       end
+      false
     end
 
     def fetch_orders_for_year(options = {})
@@ -191,6 +194,32 @@ module AmazonOrder
     end
 
     private
+
+    def sign_in_and_open_order_history
+      max_attempts = options.fetch(:sign_in_attempts, 3).to_i
+      max_attempts = 1 if max_attempts < 1
+
+      1.upto(max_attempts) do |attempt|
+        begin
+          sign_in
+          return true if go_to_amazon_order_page
+          raise AuthenticationError,
+            "Amazon order history was not reached (current_url=#{session.current_url})"
+        rescue => e
+          log "Amazon sign-in attempt #{attempt}/#{max_attempts} failed: #{e.message}"
+          raise if attempt == max_attempts
+
+          retry_url = url_origin(session.current_url)
+          log "Retrying Amazon sign-in from #{retry_url}"
+          session.visit("#{retry_url}/") if retry_url
+        end
+      end
+    end
+
+    def order_history_page?
+      session.current_url.to_s.match?(%r{/(?:your-orders/orders|gp/your-account/order-history)}) &&
+        !authentication_page?
+    end
 
     def parse_amazon_orders(filepaths)
       orders = filepaths.flat_map do |filepath|

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -37,10 +37,12 @@ module AmazonOrder
     def fetch_amazon_orders
       sign_in
       go_to_amazon_order_page
-      year_to.to_i.downto(year_from.to_i) do |year|
+      fetched_page_paths = year_to.to_i.downto(year_from.to_i).flat_map do |year|
         fetch_orders_for_year(year: year)
       end
-      fetch_order_details if options.fetch(:fetch_order_details, false)
+      if options.fetch(:fetch_order_details, false)
+        fetch_order_details(orders: parse_amazon_orders(fetched_page_paths))
+      end
     end
 
     # Fetches each order's detail page once. Order numbers, rather than URLs,
@@ -52,10 +54,11 @@ module AmazonOrder
         :continue_on_error,
         options.fetch(:continue_on_detail_error, true)
       )
+      orders = fetch_options.fetch(:orders) { load_amazon_orders }
       origin = order_history_origin
       seen = {}
 
-      load_amazon_orders.each do |order|
+      orders.each do |order|
         order_number = order.order_number.to_s
         path = order.order_details_path.to_s
         next if order_number.empty? || path.empty? || seen[order_number]
@@ -88,13 +91,7 @@ module AmazonOrder
     end
 
     def load_amazon_orders
-      orders = []
-      Dir.glob(file_glob_pattern).each do |filepath|
-        parser = AmazonOrder::Parser.new(filepath)
-        log "Loading #{filepath} with #{parser.orders.size} orders"
-        orders += parser.orders
-      end
-      orders.sort_by{|o| -o.fetched_at.to_i }.uniq(&:order_number)
+      parse_amazon_orders(Dir.glob(file_glob_pattern))
     end
 
     def file_glob_pattern
@@ -134,14 +131,16 @@ module AmazonOrder
 
     def fetch_orders_for_year(options = {})
       year = options.fetch(:year, Time.current.year)
+      saved_page_paths = []
       if switch_year(year)
-        save_page_for(year, current_page_node.try!(:text))
+        saved_page_paths << save_page_for(year, current_page_node.try!(:text))
         while (node = next_page_node) do
           session.visit node.attr('href')
-          save_page_for(year, current_page_node.text)
+          saved_page_paths << save_page_for(year, current_page_node.text)
           break if limit && limit <= current_page_node.text.to_i
         end
       end
+      saved_page_paths
     end
 
     def switch_year(year)
@@ -162,6 +161,7 @@ module AmazonOrder
       log "Saving year:#{year} page:#{page}"
       path = ['order', year.to_s, "p#{page}", Time.current.strftime('%Y%m%d%H%M%S')].join('-') + '.html'
       session.save_page(File.join(base_dir, path))
+      File.join(Capybara.save_path, base_dir, path)
     end
 
     def selected_year
@@ -184,6 +184,15 @@ module AmazonOrder
     end
 
     private
+
+    def parse_amazon_orders(filepaths)
+      orders = filepaths.flat_map do |filepath|
+        parser = AmazonOrder::Parser.new(filepath)
+        log "Loading #{filepath} with #{parser.orders.size} orders"
+        parser.orders
+      end
+      orders.sort_by{|o| -o.fetched_at.to_i }.uniq(&:order_number)
+    end
 
     def order_history_origin
       @order_history_origin ||= url_origin(session.current_url)

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -12,8 +12,6 @@ module AmazonOrder
       @options = options
       @client = AmazonAuth::Client.new(@options)
       extend(AmazonAuth::SessionExtension)
-      @amazon_auth_sign_in = method(:sign_in)
-      define_singleton_method(:sign_in) { sign_in_with_retry }
     end
 
     def base_dir
@@ -115,6 +113,27 @@ module AmazonOrder
       @_writer ||= AmazonOrder::Writer.new(file_glob_pattern)
     end
 
+    def sign_in_with_retry
+      max_attempts = options.fetch(:sign_in_attempts, 3).to_i
+      max_attempts = 1 if max_attempts < 1
+
+      1.upto(max_attempts) do |attempt|
+        begin
+          result = @client.sign_in
+          return true if result && !authentication_page?
+          raise AuthenticationError,
+            "Amazon sign-in did not complete (current_url=#{session.current_url})"
+        rescue => e
+          log "Amazon sign-in attempt #{attempt}/#{max_attempts} failed: #{e.message}"
+          raise AuthenticationError, e.message if attempt == max_attempts
+
+          retry_url = url_origin(session.current_url)
+          log "Retrying Amazon sign-in from #{retry_url}"
+          session.visit("#{retry_url}/") if retry_url
+        end
+      end
+    end
+
     def go_to_amazon_order_page
       return true if order_history_page?
 
@@ -190,27 +209,6 @@ module AmazonOrder
 
     private
 
-    def sign_in_with_retry
-      max_attempts = options.fetch(:sign_in_attempts, 3).to_i
-      max_attempts = 1 if max_attempts < 1
-
-      1.upto(max_attempts) do |attempt|
-        begin
-          result = @amazon_auth_sign_in.call
-          return true if result && !authentication_page?
-          raise AuthenticationError,
-            "Amazon sign-in did not complete (current_url=#{session.current_url})"
-        rescue => e
-          log "Amazon sign-in attempt #{attempt}/#{max_attempts} failed: #{e.message}"
-          raise AuthenticationError, e.message if attempt == max_attempts
-
-          retry_url = url_origin(session.current_url)
-          log "Retrying Amazon sign-in from #{retry_url}"
-          session.visit("#{retry_url}/") if retry_url
-        end
-      end
-    end
-
     def ensure_order_history_session
       return true if order_history_page?
 
@@ -218,7 +216,7 @@ module AmazonOrder
     end
 
     def sign_in_and_open_order_history
-      sign_in
+      sign_in_with_retry
       return true if go_to_amazon_order_page
 
       raise AuthenticationError,

--- a/lib/amazon_order/client.rb
+++ b/lib/amazon_order/client.rb
@@ -213,7 +213,7 @@ module AmazonOrder
     end
 
     def order_history_page?
-      session.current_url.to_s.match?(%r{/(?:your-orders/orders|gp/your-account/order-history)}) &&
+      session.current_url.to_s.match?(%r{/(?:your-orders/orders|gp/(?:your-account|css)/order-history)}) &&
         !authentication_page?
     end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -5,11 +5,12 @@ describe AmazonOrder::Client do
 
   describe '#fetch_order_details' do
     let(:save_path) { "tmp/client-unit-#{Process.pid}" }
+    let(:auth_client) { double('amazon auth client') }
     let(:session) { double('session', current_url: 'https://www.amazon.co.jp/your-orders/orders') }
     let(:client) { AmazonOrder::Client.new(base_dir: 'orders') }
 
     before do
-      allow(AmazonAuth::Client).to receive(:new).and_return(double('amazon auth client'))
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
       Capybara.save_path = save_path
       allow(client).to receive(:session).and_return(session)
       allow(client).to receive(:wait_for_selector).with('body')
@@ -91,6 +92,25 @@ describe AmazonOrder::Client do
       expect(session).to have_received(:visit).with('https://www.amazon.co.jp/detail/2')
       expect(session).to have_received(:save_page).once.with(include('order-detail-ok-2-'))
       expect(client).to have_received(:log).with(include('order=failed-1', 'url=https://www.amazon.co.jp/detail/1'))
+    end
+  end
+
+  describe '#sign_in' do
+    let(:auth_client) { double('amazon auth client', sign_in: nil) }
+    let(:session) { double('session', current_url: 'https://www.amazon.co.jp/ap/signin') }
+    let(:client) { AmazonOrder::Client.new }
+
+    before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
+      allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<input id="ap_email">'))
+    end
+
+    it 'stops immediately when amazon_auth leaves the browser on a sign-in page' do
+      expect { client.sign_in }.to raise_error(
+        AmazonOrder::Client::AuthenticationError,
+        include('https://www.amazon.co.jp/ap/signin')
+      )
     end
   end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -3,6 +3,37 @@ require 'spec_helper'
 describe AmazonOrder::Client do
   Order = Struct.new(:order_number, :order_details_path)
 
+  describe '#fetch_amazon_orders with order details enabled' do
+    let(:auth_client) { double('amazon auth client') }
+    let(:client) do
+      AmazonOrder::Client.new(
+        fetch_order_details: true,
+        year_from: 2025,
+        year_to: 2025,
+        limit: 2
+      )
+    end
+
+    before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
+      allow(client).to receive(:sign_in)
+      allow(client).to receive(:go_to_amazon_order_page)
+    end
+
+    it 'fetches details only for order-list pages downloaded by the current run' do
+      current_paths = %w[tmp/orders/order-2025-p1.html tmp/orders/order-2025-p2.html]
+      current_orders = [Order.new('current-1', '/detail/1')]
+      allow(client).to receive(:fetch_orders_for_year).with(year: 2025).and_return(current_paths)
+      allow(client).to receive(:parse_amazon_orders).with(current_paths).and_return(current_orders)
+      allow(client).to receive(:fetch_order_details)
+      expect(client).not_to receive(:load_amazon_orders)
+
+      client.fetch_amazon_orders
+
+      expect(client).to have_received(:fetch_order_details).with(orders: current_orders)
+    end
+  end
+
   describe '#fetch_order_details' do
     let(:save_path) { "tmp/client-unit-#{Process.pid}" }
     let(:auth_client) { double('amazon auth client') }

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -33,9 +33,8 @@ describe AmazonOrder::Client do
     end
   end
 
-  describe '#sign_in' do
+  describe '#sign_in_with_retry' do
     let(:auth_client) { double('amazon auth client') }
-    let(:amazon_auth_sign_in) { double('amazon_auth sign_in') }
     let(:session) { double('session', current_url: 'https://www.amazon.co.jp/') }
     let(:client) { AmazonOrder::Client.new(sign_in_attempts: 3) }
 
@@ -45,28 +44,27 @@ describe AmazonOrder::Client do
       allow(client).to receive(:doc).and_return(Nokogiri::HTML('<html><body>home</body></html>'))
       allow(client).to receive(:log)
       allow(session).to receive(:visit)
-      client.instance_variable_set(:@amazon_auth_sign_in, amazon_auth_sign_in)
     end
 
     it 'revisits the Amazon origin and retries the underlying sign-in until it succeeds' do
-      allow(amazon_auth_sign_in).to receive(:call).and_return(false, false, true)
+      allow(auth_client).to receive(:sign_in).and_return(false, false, true)
 
-      expect(client.sign_in).to be true
+      expect(client.sign_in_with_retry).to be true
 
-      expect(amazon_auth_sign_in).to have_received(:call).exactly(3).times
+      expect(auth_client).to have_received(:sign_in).exactly(3).times
       expect(session).to have_received(:visit).with('https://www.amazon.co.jp/').twice
       expect(client).to have_received(:log).with(include('attempt 1/3 failed'))
       expect(client).to have_received(:log).with(include('attempt 2/3 failed'))
     end
 
     it 'raises after all underlying sign-in attempts fail' do
-      allow(amazon_auth_sign_in).to receive(:call).and_return(false)
+      allow(auth_client).to receive(:sign_in).and_return(false)
 
-      expect { client.sign_in }.to raise_error(
+      expect { client.sign_in_with_retry }.to raise_error(
         AmazonOrder::Client::AuthenticationError,
         include('sign-in did not complete')
       )
-      expect(amazon_auth_sign_in).to have_received(:call).exactly(3).times
+      expect(auth_client).to have_received(:sign_in).exactly(3).times
     end
   end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -9,6 +9,7 @@ describe AmazonOrder::Client do
     let(:client) { AmazonOrder::Client.new(base_dir: 'orders') }
 
     before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(double('amazon auth client'))
       Capybara.save_path = save_path
       allow(client).to receive(:session).and_return(session)
       allow(client).to receive(:wait_for_selector).with('body')

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -84,6 +84,12 @@ describe AmazonOrder::Client do
 
       expect(session).to have_received(:visit).with('https://www.amazon.com/gp/order-details?id=1')
       expect(session).to have_received(:visit).with('https://www.audible.co.jp/account/purchase-history?id=2')
+      expect(client).to have_received(:log).with(
+        include('Fetching order detail (1/2)', 'order=amazon-1')
+      )
+      expect(client).to have_received(:log).with(
+        include('Saving order detail (2/2)', 'order=audible-1')
+      )
     end
 
     it 'skips an existing detail unless force is enabled' do

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -16,8 +16,7 @@ describe AmazonOrder::Client do
 
     before do
       allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
-      allow(client).to receive(:sign_in)
-      allow(client).to receive(:go_to_amazon_order_page)
+      allow(client).to receive(:sign_in_and_open_order_history)
     end
 
     it 'fetches details only for order-list pages downloaded by the current run' do
@@ -31,6 +30,33 @@ describe AmazonOrder::Client do
       client.fetch_amazon_orders
 
       expect(client).to have_received(:fetch_order_details).with(orders: current_orders)
+    end
+  end
+
+  describe 'sign-in retry from #fetch_amazon_orders' do
+    let(:auth_client) { double('amazon auth client') }
+    let(:session) { double('session', current_url: 'https://www.amazon.co.jp/') }
+    let(:client) do
+      AmazonOrder::Client.new(year_from: 2025, year_to: 2025, sign_in_attempts: 3)
+    end
+
+    before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
+      allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:sign_in)
+      allow(client).to receive(:go_to_amazon_order_page).and_return(false, false, true)
+      allow(client).to receive(:fetch_orders_for_year).and_return([])
+      allow(client).to receive(:log)
+      allow(session).to receive(:visit)
+    end
+
+    it 'revisits the Amazon origin and retries up to the configured attempt count' do
+      client.fetch_amazon_orders
+
+      expect(client).to have_received(:sign_in).exactly(3).times
+      expect(session).to have_received(:visit).with('https://www.amazon.co.jp/').twice
+      expect(client).to have_received(:log).with(include('attempt 1/3 failed'))
+      expect(client).to have_received(:log).with(include('attempt 2/3 failed'))
     end
   end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -70,6 +70,27 @@ describe AmazonOrder::Client do
     end
   end
 
+  describe '#go_to_amazon_order_page' do
+    let(:auth_client) { double('amazon auth client') }
+    let(:session) do
+      double(
+        'session',
+        current_url: 'https://www.amazon.co.jp//gp/css/order-history?ref_=nav_orders_first'
+      )
+    end
+    let(:client) { AmazonOrder::Client.new }
+
+    before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
+      allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<html><body>orders</body></html>'))
+    end
+
+    it 'recognizes the legacy gp/css order-history URL as a successful arrival' do
+      expect(client.go_to_amazon_order_page).to be true
+    end
+  end
+
   describe '#fetch_order_details' do
     let(:save_path) { "tmp/client-unit-#{Process.pid}" }
     let(:auth_client) { double('amazon auth client') }

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -33,41 +33,40 @@ describe AmazonOrder::Client do
     end
   end
 
-  describe 'sign-in retry from #fetch_amazon_orders' do
+  describe '#sign_in' do
     let(:auth_client) { double('amazon auth client') }
+    let(:amazon_auth_sign_in) { double('amazon_auth sign_in') }
     let(:session) { double('session', current_url: 'https://www.amazon.co.jp/') }
-    let(:client) do
-      AmazonOrder::Client.new(year_from: 2025, year_to: 2025, sign_in_attempts: 3)
-    end
+    let(:client) { AmazonOrder::Client.new(sign_in_attempts: 3) }
 
     before do
       allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
       allow(client).to receive(:session).and_return(session)
-      allow(client).to receive(:order_history_page?).and_return(false)
-      allow(client).to receive(:sign_in)
-      allow(client).to receive(:go_to_amazon_order_page).and_return(false, false, true)
-      allow(client).to receive(:fetch_orders_for_year).and_return([])
+      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<html><body>home</body></html>'))
       allow(client).to receive(:log)
       allow(session).to receive(:visit)
+      client.instance_variable_set(:@amazon_auth_sign_in, amazon_auth_sign_in)
     end
 
-    it 'revisits the Amazon origin and retries up to the configured attempt count' do
-      client.fetch_amazon_orders
+    it 'revisits the Amazon origin and retries the underlying sign-in until it succeeds' do
+      allow(amazon_auth_sign_in).to receive(:call).and_return(false, false, true)
 
-      expect(client).to have_received(:sign_in).exactly(3).times
+      expect(client.sign_in).to be true
+
+      expect(amazon_auth_sign_in).to have_received(:call).exactly(3).times
       expect(session).to have_received(:visit).with('https://www.amazon.co.jp/').twice
       expect(client).to have_received(:log).with(include('attempt 1/3 failed'))
       expect(client).to have_received(:log).with(include('attempt 2/3 failed'))
     end
 
-    it 'raises after all attempts finish without reaching order history' do
-      allow(client).to receive(:go_to_amazon_order_page).and_return(false)
+    it 'raises after all underlying sign-in attempts fail' do
+      allow(amazon_auth_sign_in).to receive(:call).and_return(false)
 
-      expect { client.fetch_amazon_orders }.to raise_error(
+      expect { client.sign_in }.to raise_error(
         AmazonOrder::Client::AuthenticationError,
-        include('order history was not reached')
+        include('sign-in did not complete')
       )
-      expect(client).to have_received(:sign_in).exactly(3).times
+      expect(amazon_auth_sign_in).to have_received(:call).exactly(3).times
     end
   end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -1,34 +1,132 @@
 require 'spec_helper'
 
 describe AmazonOrder::Client do
-  before do
-    skip('set your amazon credentials using envchain. See README and amazon_auth gem.') unless ENV['AMAZON_USERNAME_CODE']
-    Capybara.save_path = "tmp/testdir/#{Time.now.strftime('%Y%m%d%H%M%S')}" # Switch working directory to start without the file for cookie
+  Order = Struct.new(:order_number, :order_details_path)
+
+  describe '#fetch_order_details' do
+    let(:save_path) { "tmp/client-unit-#{Process.pid}" }
+    let(:session) { double('session', current_url: 'https://www.amazon.co.jp/your-orders/orders') }
+    let(:client) { AmazonOrder::Client.new(base_dir: 'orders') }
+
+    before do
+      Capybara.save_path = save_path
+      allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:wait_for_selector).with('body')
+      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<html><body>detail</body></html>'))
+      allow(client).to receive(:log)
+      allow(session).to receive(:visit)
+      allow(session).to receive(:save_page)
+    end
+
+    after do
+      Capybara.save_path = 'tmp'
+      FileUtils.rm_rf(save_path)
+    end
+
+    def orders(*values)
+      allow(client).to receive(:load_amazon_orders).and_return(values)
+    end
+
+    it 'deduplicates by order number, resolves relative links against the original origin, and saves safely' do
+      orders(
+        Order.new('123/45:*?', '/gp/order-details?ref_=one'),
+        Order.new('123/45:*?', 'https://www.amazon.co.jp/gp/order-details?ref_=two')
+      )
+
+      client.fetch_order_details
+
+      expect(session).to have_received(:visit).once.with('https://www.amazon.co.jp/gp/order-details?ref_=one')
+      expect(session).to have_received(:save_page).once.with(
+        match(%r{\Aorders/details/order-detail-123_45-\d+\.html\z})
+      )
+    end
+
+    it 'visits Amazon and Audible absolute URLs without changing them' do
+      orders(
+        Order.new('amazon-1', 'https://www.amazon.com/gp/order-details?id=1'),
+        Order.new('audible-1', 'https://www.audible.co.jp/account/purchase-history?id=2')
+      )
+
+      client.fetch_order_details
+
+      expect(session).to have_received(:visit).with('https://www.amazon.com/gp/order-details?id=1')
+      expect(session).to have_received(:visit).with('https://www.audible.co.jp/account/purchase-history?id=2')
+    end
+
+    it 'skips an existing detail unless force is enabled' do
+      orders(Order.new('existing-1', '/detail/1'))
+      directory = File.join(save_path, 'orders', 'details')
+      FileUtils.mkdir_p(directory)
+      File.write(File.join(directory, 'order-detail-existing-1-20200101000000000.html'), 'saved')
+
+      client.fetch_order_details
+      expect(session).not_to have_received(:visit)
+
+      client.fetch_order_details(force: true)
+      expect(session).to have_received(:visit).once
+    end
+
+    it 'does not save a sign-in redirect' do
+      orders(Order.new('auth-1', '/detail/1'))
+      allow(session).to receive(:current_url).and_return(
+        'https://www.amazon.co.jp/your-orders/orders',
+        'https://www.amazon.co.jp/ap/signin'
+      )
+
+      client.fetch_order_details
+
+      expect(session).not_to have_received(:save_page)
+      expect(client).to have_received(:log).with(include('order=auth-1', 'url=https://www.amazon.co.jp/detail/1'))
+    end
+
+    it 'logs one failed order and continues with the next one' do
+      orders(Order.new('failed-1', '/detail/1'), Order.new('ok-2', '/detail/2'))
+      allow(session).to receive(:visit) do |url|
+        raise 'network failure' if url.end_with?('/detail/1')
+      end
+
+      client.fetch_order_details(continue_on_error: true)
+
+      expect(session).to have_received(:visit).with('https://www.amazon.co.jp/detail/2')
+      expect(session).to have_received(:save_page).once.with(include('order-detail-ok-2-'))
+      expect(client).to have_received(:log).with(include('order=failed-1', 'url=https://www.amazon.co.jp/detail/1'))
+    end
   end
 
-  after do
-    # Restore the default not to affect other spec
-    Capybara.save_path = 'tmp'
-    FileUtils.rm_rf('tmp/testdir') if File.exist?('tmp/testdir')
-  end
+  describe 'live Amazon access' do
+    before do
+      skip('set your amazon credentials using envchain. See README and amazon_auth gem.') unless ENV['AMAZON_USERNAME_CODE']
+    end
 
-  it "fetches amazon orders successfully" do
-    client = AmazonOrder::Client.new(year_from: Time.current.year - 1, verbose: true, limit: 3)
-    client.fetch_amazon_orders
-    expect(client.session.current_url).to match(%r{/your-orders/orders})
-    orders = client.load_amazon_orders
-    expect(orders.size).to be > 0
-  end
+    before do
+      # Switch working directory to start without the file for cookie
+      Capybara.save_path = "tmp/testdir/#{Time.now.strftime('%Y%m%d%H%M%S')}"
+    end
 
-  it "logins successfully with keeping cookie" do
-    client = AmazonOrder::Client.new(keep_cookie: true, verbose: true, limit: 2)
-    client.sign_in
-    client.go_to_amazon_order_page
-    expect(client.session.current_url).to match(%r{/order-history})
+    after do
+      # Restore the default not to affect other spec
+      Capybara.save_path = 'tmp'
+      FileUtils.rm_rf('tmp/testdir') if File.exist?('tmp/testdir')
+    end
 
-    client.session.reset!
-    client.sign_in
-    client.go_to_amazon_order_page
-    expect(client.session.current_url).to match(%r{/order-history})
+    it "fetches amazon orders successfully" do
+      client = AmazonOrder::Client.new(year_from: Time.current.year - 1, verbose: true, limit: 3)
+      client.fetch_amazon_orders
+      expect(client.session.current_url).to match(%r{/your-orders/orders})
+      orders = client.load_amazon_orders
+      expect(orders.size).to be > 0
+    end
+
+    it "logins successfully with keeping cookie" do
+      client = AmazonOrder::Client.new(keep_cookie: true, verbose: true, limit: 2)
+      client.sign_in
+      client.go_to_amazon_order_page
+      expect(client.session.current_url).to match(%r{/order-history})
+
+      client.session.reset!
+      client.sign_in
+      client.go_to_amazon_order_page
+      expect(client.session.current_url).to match(%r{/order-history})
+    end
   end
 end

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -16,7 +16,7 @@ describe AmazonOrder::Client do
 
     before do
       allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
-      allow(client).to receive(:sign_in_and_open_order_history)
+      allow(client).to receive(:ensure_order_history_session)
     end
 
     it 'fetches details only for order-list pages downloaded by the current run' do
@@ -43,6 +43,7 @@ describe AmazonOrder::Client do
     before do
       allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
       allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:order_history_page?).and_return(false)
       allow(client).to receive(:sign_in)
       allow(client).to receive(:go_to_amazon_order_page).and_return(false, false, true)
       allow(client).to receive(:fetch_orders_for_year).and_return([])
@@ -101,6 +102,7 @@ describe AmazonOrder::Client do
       allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
       Capybara.save_path = save_path
       allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:ensure_order_history_session)
       allow(client).to receive(:wait_for_selector).with('body')
       allow(client).to receive(:doc).and_return(Nokogiri::HTML('<html><body>detail</body></html>'))
       allow(client).to receive(:log)
@@ -169,7 +171,10 @@ describe AmazonOrder::Client do
         'https://www.amazon.co.jp/ap/signin'
       )
 
-      client.fetch_order_details
+      expect { client.fetch_order_details }.to raise_error(
+        AmazonOrder::Client::AuthenticationError,
+        'authentication page was displayed'
+      )
 
       expect(session).not_to have_received(:save_page)
       expect(client).to have_received(:log).with(
@@ -190,6 +195,31 @@ describe AmazonOrder::Client do
       expect(client).to have_received(:log).with(
         include('Failed to fetch order detail', 'order=failed-1', 'url=https://www.amazon.co.jp/detail/1')
       )
+    end
+  end
+
+  describe '#fetch_order_details authentication' do
+    let(:auth_client) { double('amazon auth client') }
+    let(:session) { double('session', current_url: 'https://www.amazon.co.jp/ap/signin') }
+    let(:client) { AmazonOrder::Client.new }
+
+    before do
+      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
+      allow(client).to receive(:session).and_return(session)
+      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<input id="ap_email">'))
+      allow(client).to receive(:sign_in_and_open_order_history).and_raise(
+        AmazonOrder::Client::AuthenticationError,
+        'sign-in failed after 3 attempts'
+      )
+      allow(client).to receive(:load_amazon_orders)
+    end
+
+    it 'authenticates before loading saved orders and stops when authentication fails' do
+      expect { client.fetch_order_details }.to raise_error(
+        AmazonOrder::Client::AuthenticationError,
+        include('3 attempts')
+      )
+      expect(client).not_to have_received(:load_amazon_orders)
     end
   end
 

--- a/spec/amazon_order/client_spec.rb
+++ b/spec/amazon_order/client_spec.rb
@@ -58,6 +58,16 @@ describe AmazonOrder::Client do
       expect(client).to have_received(:log).with(include('attempt 1/3 failed'))
       expect(client).to have_received(:log).with(include('attempt 2/3 failed'))
     end
+
+    it 'raises after all attempts finish without reaching order history' do
+      allow(client).to receive(:go_to_amazon_order_page).and_return(false)
+
+      expect { client.fetch_amazon_orders }.to raise_error(
+        AmazonOrder::Client::AuthenticationError,
+        include('order history was not reached')
+      )
+      expect(client).to have_received(:sign_in).exactly(3).times
+    end
   end
 
   describe '#fetch_order_details' do
@@ -141,7 +151,9 @@ describe AmazonOrder::Client do
       client.fetch_order_details
 
       expect(session).not_to have_received(:save_page)
-      expect(client).to have_received(:log).with(include('order=auth-1', 'url=https://www.amazon.co.jp/detail/1'))
+      expect(client).to have_received(:log).with(
+        include('Failed to fetch order detail', 'order=auth-1', 'url=https://www.amazon.co.jp/detail/1')
+      )
     end
 
     it 'logs one failed order and continues with the next one' do
@@ -154,25 +166,8 @@ describe AmazonOrder::Client do
 
       expect(session).to have_received(:visit).with('https://www.amazon.co.jp/detail/2')
       expect(session).to have_received(:save_page).once.with(include('order-detail-ok-2-'))
-      expect(client).to have_received(:log).with(include('order=failed-1', 'url=https://www.amazon.co.jp/detail/1'))
-    end
-  end
-
-  describe '#sign_in' do
-    let(:auth_client) { double('amazon auth client', sign_in: nil) }
-    let(:session) { double('session', current_url: 'https://www.amazon.co.jp/ap/signin') }
-    let(:client) { AmazonOrder::Client.new }
-
-    before do
-      allow(AmazonAuth::Client).to receive(:new).and_return(auth_client)
-      allow(client).to receive(:session).and_return(session)
-      allow(client).to receive(:doc).and_return(Nokogiri::HTML('<input id="ap_email">'))
-    end
-
-    it 'stops immediately when amazon_auth leaves the browser on a sign-in page' do
-      expect { client.sign_in }.to raise_error(
-        AmazonOrder::Client::AuthenticationError,
-        include('https://www.amazon.co.jp/ap/signin')
+      expect(client).to have_received(:log).with(
+        include('Failed to fetch order detail', 'order=failed-1', 'url=https://www.amazon.co.jp/detail/1')
       )
     end
   end


### PR DESCRIPTION
### Motivation

- Provide a way to download per-order detail pages after the order-list pages have been collected, avoiding duplicate downloads and enabling safe local archiving for further parsing. 
- Ensure relative detail links are resolved correctly even after cross-domain redirects and make filenames safe for all order numbers. 

### Description

- Add public method `Client#fetch_order_details` and make `fetch_amazon_orders` optionally run it when `fetch_order_details: true` is passed. (file: `lib/amazon_order/client.rb`) 
- Read orders via existing `load_amazon_orders`, deduplicate by `order_number`, normalize order numbers to safe filenames, and save detail HTML files under `File.join(base_dir, 'details')`. (file: `lib/amazon_order/client.rb`) 
- Resolve relative URLs against the order-history origin and allow absolute Amazon/Audible URLs directly; detect authentication redirects and avoid saving sign-in pages. (file: `lib/amazon_order/client.rb`) 
- Add options for skipping already-saved details by default, `force: true` to re-fetch, and `continue_on_error` to control whether a single failing order aborts the rest. (file: `lib/amazon_order/client.rb`) 
- Add unit tests that use a session test-double to validate deduplication, relative/absolute URL handling, filename normalization, skip-without-force behavior, sign-in redirect rejection, and continue-on-error behavior. (file: `spec/amazon_order/client_spec.rb`) 
- Document opt-in usage, separate invocation examples, force/continuation options, storage location, and a clear warning that saved detail HTML can contain personal information in `README.md`.

### Testing

- Ran syntax checks: `ruby -c lib/amazon_order/client.rb` and `ruby -c spec/amazon_order/client_spec.rb` which both returned `Syntax OK`. 
- Ran `git diff --check` and code formatting checks (no issues reported). 
- Attempted to run `bundle install && bundle exec rspec spec/amazon_order/client_spec.rb` but `bundle install` could not complete in this environment because rubygems.org returned HTTP 403, so the RSpec run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cbcad1a8c8332a646d1cf3b629f6c)